### PR TITLE
add ElectronMail

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,7 @@
 
 ### Email
 - [![Open-Source Software][OSS Icon]](https://git.claws-mail.org/) [Claws](https://www.claws-mail.org/) - Claws is an email client and news reader, featuring sophisticated interface, easy configuration, intuitive operation, abundant features and plugins, robustness and stability.
+- [![Open-Source Software][OSS Icon]](https://github.com/vladimiry/ElectronMail) [ElectronMail](https://github.com/vladimiry/ElectronMail) - ElectronMail is an Electron-based unofficial desktop client for ProtonMail and Tutanota end-to-end encrypted email providers.
 - [![Open-Source Software][OSS Icon]](https://gitlab.gnome.org/GNOME/evolution/) [Evolution](https://wiki.gnome.org/Apps/Evolution/) - Evolution is a personal information management application that provides integrated mail, calendaring and address book functionality.
 - [![Open-Source Software][OSS Icon]](https://gitlab.gnome.org/GNOME/geary/) [Geary](https://wiki.gnome.org/Apps/Geary) - Geary is an email application built for GNOME 3. It allows you to read and send email with a simple, modern interface.
 - ![Nonfree][Money Icon] [Hiri](https://www.hiri.com/) - Hiri is a business focused desktop e-mail client for sending and receiving e-mails, managing calendars, contacts, and tasks.


### PR DESCRIPTION
## Project URL
https://github.com/vladimiry/ElectronMail

## Category
Email

## Description
<!--- Describe your changes in detail -->
Unofficial desktop app for ProtonMail and Tutanota end-to-end encrypted email providers 

## Why it should be included to the catalog
The app provides unique features that are not supported by the official in-browser web clients. Such as for example offline access to the email messages, full-text search (fully functional in offline), multiple accounts support, automatic login, and many more (see [readme](https://github.com/vladimiry/ElectronMail/blob/master/README.md) file for details).

## Checklist
- [x] Only one project/change is in this pull request
- [x] Has a commit from less than 2 years ago
- [x] Has a clear README in English
