### PR TITLE
Add Gamescope - the micro-compositor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1077,6 +1077,7 @@
 
 ### Compositors
 - [![Open-Source Software][OSS Icon]](https://github.com/yshui/compton) [Compton](https://github.com/yshui/compton) - Compton is a standalone composite manager, suitable for use with window managers that do not natively provide compositing functionality.
+- [![Open-Source Software][OSS Icon]](https://github.com/Plagman/gamescope) [Gamescope](https://github.com/Plagman/gamescope) - Gamescope is a micro-compositor that provides a sandboxed Xwayland desktop with independent input, resolution, and refresh rate.
 - [![Open-Source Software][OSS Icon]](https://github.com/swaywm/sway) [Sway](https://swaywm.org) - Sway is tiling Wayland compositor and a drop-in replacement for the i3 window manager for X11.
 - [![Open-Source Software][OSS Icon]](https://cgit.freedesktop.org/xorg/app/xcompmgr) [Xcompmgr](https://cgit.freedesktop.org/xorg/app/xcompmgr) - Xcompmgr is a simple composite manager capable of rendering drop shadows and, with the use of the transset utility, primitive window transparency.
 


### PR DESCRIPTION
Allows for independent scaling of a window.

Context:
>  One of the aims here ended up being to have it work on a normal desktop, not just in a single-screen / single-activity like SteamOS did with steamcompmgr. The idea is that with Gamescope the game cannot interfere with your Linux desktop, while you also get more direct control over it for things like input, resolution, refresh rate and more. Griffais showed an example of Portal not working well with an Ultrawide monitor, and then when run with Gamescope at least the rendering was correct due to the sandboxing. Example below, launched as normal and then launched with Gamescope.

https://www.gamingonlinux.com/2020/09/valve-developer-shows-off-gamescope-for-linux-at-xdc-2020/page=2#r190150