### PR TITLE
Add IceWM (stacking window manager)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1251,6 +1251,7 @@ the WebKit rendering engine.
 - [![Open-Source Software][OSS Icon]](https://github.com/bbidulock/blackboxwm) [Blackbox](https://github.com/bbidulock/blackboxwm) - A fast, lightweight window manager for the X Window System, without all those annoying library dependencies.
 - [![Open-Source Software][OSS Icon]](https://github.com/fluxbox/fluxbox) [Fluxbox](http://fluxbox.org) - A window manager for X that was based on the Blackbox 0.61.1 code.
 - [![Open-Source Software][OSS Icon]](https://github.com/danakj/openbox) [Openbox](http://openbox.org) - A highly configurable, next generation window manager with extensive standards support.
+- [![Open-Source Software][OSS Icon]](https://github.com/ice-wm/icewm) [IceWM](https://ice-wm.org) - A window manager for the X Window System. The goal of IceWM is speed, simplicity, and not getting in the user’s way.
 
 ### Tiling window managers
 - [![Open-Source Software][OSS Icon]](https://github.com/baskerville/bspwm) [Bspwm](https://github.com/baskerville/bspwm/wiki) - Bspwm is a tiling window manager that represents windows as the leaves of a full binary tree.


### PR DESCRIPTION
Hi, I would love to see the excellent "IceWM" in the "stacking window managers" section.

It is a wonderful stacking window manager that can be used as standalone WM or that can be integrated with Gnome or KDE environments (for instance).
It is also the default WM for antiX Linux.

I use it daily as a standalone WM and I love it :)

https://github.com/ice-wm/icewm
https://ice-wm.org/