### PR TITLE
Fixe Gummi hyperlinks

### DIFF
--- a/README_es-ES.md
+++ b/README_es-ES.md
@@ -661,7 +661,7 @@ es un creador de imágenes GIF de código abierto.
 - [WPS office](http://wps-community.org/) - Un conjunto de programas de oficina popular en China. Se traduce y funciona bien en otros idiomas.
 
 #### LaTeX
-- [![Open-Source Software][OSS Icon]](https://github.com/alexandervdm/gummi) Gummi [gtk2](https://github.com/alexandervdm/gummi)|[gtk3](https://github.com/aitjcize/Gummi) -Gummi es un editor sencillo con plantillas, corrector ortográfico y guías.
+- [![Open-Source Software][OSS Icon]](https://github.com/alexandervdm/gummi) [Gummi](https://gummi.app/) -Gummi es un editor sencillo con plantillas, corrector ortográfico y guías.
 - [![Open-Source Software][OSS Icon]](https://git.gnome.org/browse/latexila) [LaTeXila](https://wiki.gnome.org/Apps/LaTeXila) - LaTeXila es un editor LaTex para el entorno de escritorio de GNOME.
 - [![Open-Source Software][OSS Icon]](https://github.com/yihui/lyx) [LyX](http://www.lyx.org/) - Un editor de documentos que puede procesar archivos LaTex.
 - [![Open-Source Software][OSS Icon]](https://www.tug.org/texlive/build.html) [TexLive](https://www.tug.org/texlive/) - TeX Live proporciona una manera fácil de crear un sistema de producción de documentos "Tex".

--- a/README_fr-FR.md
+++ b/README_fr-FR.md
@@ -671,7 +671,7 @@
 - [WPS office](http://wps-community.org/) - A popular office suite in China, but is fully translated and functions well in English.
 
 #### LaTeX
-- [![Open-Source Software][OSS Icon]](https://github.com/alexandervdm/gummi) Gummi [gtk2](https://github.com/alexandervdm/gummi)|[gtk3](https://github.com/aitjcize/Gummi) - Simple latex editor with templates, spell check, and wizards.
+- [![Open-Source Software][OSS Icon]](https://github.com/alexandervdm/gummi) [Gummi](https://gummi.app/) - Simple latex editor with templates, spell check, and wizards.
 - [![Open-Source Software][OSS Icon]](https://git.gnome.org/browse/latexila) [LaTeXila](https://wiki.gnome.org/Apps/LaTeXila) - LaTeXila is a LaTeX editor for the GNOME desktop.
 - [![Open-Source Software][OSS Icon]](https://github.com/yihui/lyx) [LyX](http://www.lyx.org/) - Mature document editor that renders into LaTeX.
 - [![Open-Source Software][OSS Icon]](https://www.tug.org/texlive/build.html) [TexLive](https://www.tug.org/texlive/) - TeX Live is an easy way to get up and running with the TeX document production system.

--- a/README_pt-BR.md
+++ b/README_pt-BR.md
@@ -617,7 +617,7 @@ Ele foi projetado principalmente para ajudar a recuperar partições perdidas e/
 - [WPS office](http://wps-community.org/) - A popular office suite in China, but is fully translated and functions well in English.
 
 #### LaTeX
-- Gummi [gtk2](https://github.com/alexandervdm/gummi)|[gtk3](https://github.com/aitjcize/Gummi) - Simple latex editor with templates, spell check, and wizards. [![Open-Source Software][OSS Icon]](https://github.com/alexandervdm/gummi)
+- [Gummi](https://gummi.app/) - Simple latex editor with templates, spell check, and wizards. [![Open-Source Software][OSS Icon]](https://github.com/alexandervdm/gummi)
 - [LaTeXila](https://wiki.gnome.org/Apps/LaTeXila) - LaTeXila is a LaTeX editor for the GNOME desktop. [![Open-Source Software][OSS Icon]](https://git.gnome.org/browse/latexila)
 - [LyX](http://www.lyx.org/) - Mature document editor that renders into LaTeX .. [![Open-Source Software][OSS Icon]](https://github.com/yihui/lyx)
 - [TexLive](https://www.tug.org/texlive/) - TeX Live is an easy way to get up and running with the TeX document production system.  [![Open-Source Software][OSS Icon]](https://www.tug.org/texlive/build.html)

--- a/README_th-TH.md
+++ b/README_th-TH.md
@@ -664,7 +664,7 @@
 - [WPS office](http://wps-community.org/) - A popular office suite in China, but is fully translated and functions well in English.
 
 #### LaTeX
-- [![Open-Source Software][OSS Icon]](https://github.com/alexandervdm/gummi) Gummi [gtk2](https://github.com/alexandervdm/gummi)|[gtk3](https://github.com/aitjcize/Gummi) - Simple latex editor with templates, spell check, and wizards.
+- [![Open-Source Software][OSS Icon]](https://github.com/alexandervdm/gummi) [Gummi](https://gummi.app/) - Simple latex editor with templates, spell check, and wizards.
 - [![Open-Source Software][OSS Icon]](https://git.gnome.org/browse/latexila) [LaTeXila](https://wiki.gnome.org/Apps/LaTeXila) - LaTeXila is a LaTeX editor for the GNOME desktop.
 - [![Open-Source Software][OSS Icon]](https://github.com/yihui/lyx) [LyX](http://www.lyx.org/) - Mature document editor that renders into LaTeX.
 - [![Open-Source Software][OSS Icon]](https://www.tug.org/texlive/build.html) [TexLive](https://www.tug.org/texlive/) - TeX Live is an easy way to get up and running with the TeX document production system.

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -444,7 +444,7 @@
 - [Texmaker](http://www.xm1math.net/texmaker/) - 免费跨平台的 LaTeX 编辑器。
 - [WPS office](http://wps-community.org/) - Linux 上的最佳办公套件之一。
 - [OnlyOffice](https://www.onlyoffice.com/) - 最佳的 Linux 办公套件之一。
-- [![Open-Source Software][OSS Icon]](https://github.com/alexandervdm/gummi) [Gummi gtk2](https://github.com/alexandervdm/gummi)|[Gummi gtk3](https://github.com/aitjcize/Gummi) - 带有模板，拼写检查以及向导的简单 latex 编辑器。 
+- [![Open-Source Software][OSS Icon]](https://github.com/alexandervdm/gummi) [Gummi](https://gummi.app/) - 带有模板，拼写检查以及向导的简单 latex 编辑器。 
 - [![Open-Source Software][OSS Icon]](https://github.com/Gnucash/) [GnuCash](https://www.gnucash.org/) - GnuCash 是一款自由的会计程序，实现了复式记账系统。它最初的目标是开发出与 Intuit, Inc. 的 Quicken 类似的功能，但它还有针对小企业会计的功能。 
 - [![Open-Source Software][OSS Icon]](https://github.com/KDE/kmymoney) [KMyMoney](https://kmymoney.org/) - KMyMoney 是 KDE 的一款个人金融管理器。它的操作类似 Microsoft Money 以及 Quicken。 
 - [![Open-Source Software][OSS Icon]](https://www.libreoffice.org/about-us/source-code/) [LibreOffice](https://www.libreoffice.org/) - Linux 上的最佳办公套件。 


### PR DESCRIPTION
One of the GitHub links does not work anymore and there is a website now.