### PR TITLE
Gaming Applications/W.I.N.E: Add Kron4ek Wine Builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -709,6 +709,7 @@ _For a more comprehensive/advanced/better categorized/... list of Linux audio so
 ##### W.I.N.E.
 
 - [![Open-Source Software][oss icon]](https://github.com/GloriousEggroll/proton-ge-custom) [GE-Proton](https://github.com/GloriousEggroll/proton-ge-custom) - Compatibility tool for Steam Play based on Wine and additional components.
+- [![Open-Source Software][oss icon]](https://github.com/Kron4ek/Wine-Builds) [Kron4ek Wine Builds](https://github.com/Kron4ek/Wine-Builds) - Custom Wine builds and build scripts for Vanilla, Wine Staging, Wine-tkg and Proton.
 - [![Open-Source Software][oss icon]](https://github.com/Matoking/protontricks) [Protontricks](https://github.com/Matoking/protontricks) - This is a wrapper script that allows you to easily run Winetricks commands for Steam Play/Proton games among other common Wine features, such as launching external Windows executables.
 - [![Open-Source Software][oss icon]](https://github.com/AUNaseef/protonup) [ProtonUp](https://github.com/AUNaseef/protonup) - CLI program and API to automate the installation and update of GE-Proton.
 - [![Open-Source Software][oss icon]](https://github.com/DavidoTek/ProtonUp-Qt) [ProtonUp-Qt](https://davidotek.github.io/protonup-qt/) - Install and manage GE-Proton and Luxtorpeda for Steam and Wine-GE for Lutris with this graphical user interface.


### PR DESCRIPTION
Adds [Kron4ek Wine Builds](https://github.com/Kron4ek/Wine-Builds); provides various Wine build and build scripts. It gives easy access to prebuilt vanilla Wine binaries based on Wine and Wine-Staging, as well as builds of Proton based on Valve's Wine or with Valve's patches, but without other additions such as DXVK or vkd3d-proton. Some projects such as ProtonUp-Qt offer support for downloading these builds as well.

Kron4ek Wine build scripts are FOSS ([available on GitHub](https://github.com/Kron4ek/Wine-Builds)), licensed under the terms of the MIT license. However, Wine itself and some components used therein may be subject to different licensed; Wine, for example, is licenses under the [GNU LGPL-2.1 license](https://gitlab.winehq.org/wine/wine/-/blob/master/LICENSE).