### PR TITLE
Gaming Applications/W.I.N.E.: Add ProtonPlus

### DIFF
--- a/README.md
+++ b/README.md
@@ -709,6 +709,7 @@ _For a more comprehensive/advanced/better categorized/... list of Linux audio so
 ##### W.I.N.E.
 
 - [![Open-Source Software][oss icon]](https://github.com/GloriousEggroll/proton-ge-custom) [GE-Proton](https://github.com/GloriousEggroll/proton-ge-custom) - Compatibility tool for Steam Play based on Wine and additional components.
+- [![Open-Source Software][oss icon]](https://github.com/Vysp3r/ProtonPlus) [ProtonPlus](https://github.com/Vysp3r/ProtonPlus) - A simple Wine and Proton manager for GNOME.
 - [![Open-Source Software][oss icon]](https://github.com/Matoking/protontricks) [Protontricks](https://github.com/Matoking/protontricks) - This is a wrapper script that allows you to easily run Winetricks commands for Steam Play/Proton games among other common Wine features, such as launching external Windows executables.
 - [![Open-Source Software][oss icon]](https://github.com/AUNaseef/protonup) [ProtonUp](https://github.com/AUNaseef/protonup) - CLI program and API to automate the installation and update of GE-Proton.
 - [![Open-Source Software][oss icon]](https://github.com/DavidoTek/ProtonUp-Qt) [ProtonUp-Qt](https://davidotek.github.io/protonup-qt/) - Install and manage GE-Proton and Luxtorpeda for Steam and Wine-GE for Lutris with this graphical user interface.


### PR DESCRIPTION
Adds [ProtonPlus](https://github.com/Vysp3r/ProtonPlus); a Wine and Proton tool manager for GNOME.

ProtonPlus is FOSS ([available on GitHub](https://github.com/Vysp3r/ProtonPlus)), licensed under the terms of the GNU GPL-3.0 license.