### PR TITLE
Linux News: Add Linux Gaming Central

### DIFF
--- a/README.md
+++ b/README.md
@@ -1588,7 +1588,7 @@ _For a more comprehensive/advanced/better categorized/... list of Linux audio so
 - [Lemmy c/Linux](https://lemmy.ml/c/linux)
 - [Liliputing](https://liliputing.com/)
 - [Linoxide](https://linoxide.com/)
-- [Linux Gaming Central](https://mastodon.social/@linuxgamingcentral)
+- [Linux Gaming Central](https://linuxgamingcentral.com/)
 - [LinuxHandbook](https://linuxhandbook.com/)
 - [LinuxLinks](https://www.linuxlinks.com/)
 - [Linux official](https://www.linux.com/)

--- a/README.md
+++ b/README.md
@@ -1588,6 +1588,7 @@ _For a more comprehensive/advanced/better categorized/... list of Linux audio so
 - [Lemmy c/Linux](https://lemmy.ml/c/linux)
 - [Liliputing](https://liliputing.com/)
 - [Linoxide](https://linoxide.com/)
+- [Linux Gaming Central](https://mastodon.social/@linuxgamingcentral)
 - [LinuxHandbook](https://linuxhandbook.com/)
 - [LinuxLinks](https://www.linuxlinks.com/)
 - [Linux official](https://www.linux.com/)


### PR DESCRIPTION
Adds [Linux Gaming Central](https://linuxgamingcentral.com) to the list of Linux news sites. Owned and operated by Mark Dougherty, previously an editor at Boiling Steam from 2015-2022, Linux Gaming Central primarily focuses on Linux gaming and Steam Deck news.

The website is FOSS ([yes, really!](https://github.com/linuxgamingcentral/website)) and takes a privacy-first approach to its analytical data by avoiding Google Analytics.

Note: One of my projects has been featured on Linux Gaming Central, but I am otherwise unaffiliated; just a reader.