### PR TITLE
Audio/Music Player: Add AudioTube

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ _For a more comprehensive/advanced/better categorized/... list of Linux audio so
 
 - [![Open-Source Software][oss icon]](https://gitlab.gnome.org/World/amberol) [Amberol](https://apps.gnome.org/app/io.bassi.Amberol/) - A small and simple sound and music player that is well integrated with GNOME.
 - [![Open-Source Software][oss icon]](https://audacious-media-player.org/developers) [Audacious](https://audacious-media-player.org/) - An open source audio player that plays your music how you want it, without stealing away your computer’s resources from other tasks.
+- [![Open-Source Software][oss icon]](https://invent.kde.org/multimedia/audiotube) [AudioTube](https://apps.kde.org/audiotube/) - Feature-rich YouTube Music client for KDE, built with Kirigami.
 - [![Open-Source Software][oss icon]](https://github.com/beetbox/beets) [beets](http://beets.io/) - Beets is the media library management system for obsessive-compulsive music geeks.
 - [![Open-Source Software][oss icon]](https://github.com/CDrummond/cantata) [Cantata](https://github.com/CDrummond/cantata) - Qt5 Graphical MPD (Music Player Daemon) Client for Linux, Windows, MacOS.
 - [![Open-Source Software][oss icon]](https://github.com/ciderapp/cider) [Cider](https://cider.sh/) - A new cross-platform Apple Music experience based on Electron and Vue.js written from scratch with performance in mind.


### PR DESCRIPTION
Adds [AudioTube](https://apps.kde.org/audiotube/); a YouTube Music client built with Kirigami, and recently made part of KDE Gear as of KDE Gear 23.04.

AudioTube is FOSS ([available on KDE Invent](https://invent.kde.org/multimedia/audiotube)), licensed under the terms of the GNU GPL 2.0. Some components may be subject to different licenses but are compatible with GPL-2.0. See the project's [LICENSES](https://invent.kde.org/multimedia/audiotube/-/tree/master/LICENSES) folder for more information.