### PR TITLE
Audio/Radio: Add Kasts

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ _For a more comprehensive/advanced/better categorized/... list of Linux audio so
 #### Radio
 
 - [![Open-Source Software][oss icon]](https://github.com/chronitis/curseradio) [curseradio](https://github.com/chronitis/curseradio) - Command line radio player.
+- [![Open-Source Software][oss icon]](https://invent.kde.org/multimedia/kasts) [Kasts](https://apps.kde.org/kasts/) - Feature-rich, convergent podcast client for Linux Desktop and Mobile.
 - [![Open-Source Software][oss icon]](https://github.com/ebruck/radiotray-ng) [RadioTray-NG](https://github.com/ebruck/radiotray-ng) - An Internet radio player for Linux.
 - [![Open-Source Software][oss icon]](https://gitlab.gnome.org/World/Shortwave) [Shortwave](https://apps.gnome.org/app/de.haeckerfelix.Shortwave/) - Shortwave is an internet radio player that provides access to a station database with over 25,000 stations.
 - [![Open-Source Software][oss icon]](https://github.com/needle-and-thread/vocal) [Vocal](https://vocalproject.net/) - Podcast client for the modern desktop.


### PR DESCRIPTION
Adds [Kasts](https://apps.kde.org/kasts/); a Podcast client for the Linux Desktop and mobile, and recently made part of KDE Gear as of KDE Gear 23.04.

Kasts is FOSS ([available on KDE Invent](https://invent.kde.org/multimedia/kasts)), licensed under the terms of the GNU GPL 2.0. Some components may be subject to different licenses but are compatible with GPL-2.0. See the project's [LICENSES](https://invent.kde.org/multimedia/kasts/-/tree/master/LICENSES) folder for more information.