### PR TITLE
Editors/IDEs: Add ZeroBrane Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,6 +484,7 @@ _For a more comprehensive/advanced/better categorized/... list of Linux audio so
 - [![Open-Source Software][oss icon]](https://github.com/orbitalquark/textadept) [Textadept](https://orbitalquark.github.io/textadept/) - Minimalist text editor for programmers. Textadept is extensible with Lua programming language.
 - [![Open-Source Software][oss icon]](https://github.com/Microsoft/vscode) [VSCode](https://code.visualstudio.com) - Visual Studio Code is a lightweight but powerful source code editor which runs on your desktop and is available for Windows, OS X and Linux. It comes with built-in support for JavaScript, TypeScript and Node.js and has a rich ecosystem of extensions for other languages (C++, C#, Python, PHP, Golang) and runtimes.
 - [![Open-Source Software][oss icon]](https://github.com/VSCodium/vscodium) [VSCodium](https://vscodium.com/) - Binary releases of VS Code without MS branding/telemetry/licensing.
+- [![Open-Source Software][oss icon]](https://github.com/pkulchenko/ZeroBraneStudio) [ZeroBrane Studio](http://studio.zerobrane.com/) - A mature, lightweight, cross-platform Lua IDE with modern development features.
 
 #### Modal editors & derivatives
 


### PR DESCRIPTION
Adds [ZeroBrane Studio](https://github.com/pkulchenko/ZeroBraneStudio); a powerful Lua IDE with modern development features.

ZeroBrane Studio is FOSS ([available on GitHub](https://github.com/pkulchenko/ZeroBraneStudio)), licensed under the terms of the MIT license. However, some of its components may be under different licenses. See the project's [LICENSE](https://github.com/pkulchenko/ZeroBraneStudio/blob/master/LICENSE) document for more information. 