### PR TITLE
Games/Sandbox: Add Factorio

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,6 +662,7 @@ _For a more comprehensive/advanced/better categorized/... list of Linux audio so
 
 #### Sandbox
 
+- ![Nonfree][money icon] [Factorio](https://www.factorio.com/) - A factory building sandbox game.
 - [![Open-Source Software][oss icon]](https://github.com/minecraft-linux/mcpelauncher-manifest) [Mcpelauncher](https://mcpelauncher.readthedocs.io/en/latest/) - Unoffical Open-source launcher for Minecraft: Bedrock edition.
 - ![Nonfree][money icon] [Minecraft](https://minecraft.net) - Minecraft is a game about placing blocks and going on adventures. Explore randomly generated worlds and build amazing things from the simplest of homes to the grandest of castles.
 - [![Open-Source Software][oss icon]](https://github.com/minetest/minetest/) [Minetest](https://minetest.net) - Open-source Minecraft written in C++ (uses less resources) and includes modding API.


### PR DESCRIPTION
Adds [Factorio](https://www.factorio.com/); a factory building sandbox that has seen significant development. As well as being available on Steam and GOG, it is available directly from Wube Software's website DRM-free. They also supply a Steam key upon purchase from the website. Game keys and a DRM free release is also available from Humble Bundle.

Factorio is proprietary, but treats Linux as a first-class platform. Linux performance has been known by the community to be stellar, and the developers even recently introduced stable, tested, native Wayland support. This was previously available with the used SDL version via an environment option, but had some issues. A recent release fixed remaining issues on Wayland and the game is now perfectly playable natively on Wayland. Not many games offer this option and fewer actually work to improve their Wayland support. Native Wayland support is notable for users with scaled displays that want to play games at their display's native resolution. This brings Factorio into **full parity** with its other target PC platforms, meaning players are not missing out on any features by playing on Linux.

I feel it is justified to include Factorio on this list as a result of the developers consistently maintaining a first-class Linux port, with the most recent example being official native Wayland support (i.e. it was tested and noted in the changelogs) beyond simply bumping the bundled SDL version. As well as this, though the game is proprietary, it is available DRM-free from several places.

Putting aside any gameplay elements, I think these factors earn Factorio the title of "Awesome Linux Software" :-)