### PR TITLE
System Info: Add screenFetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1453,6 +1453,7 @@ _For a more comprehensive/advanced/better categorized/... list of Linux audio so
 - [![Open-Source Software][oss icon]](https://github.com/dylanaraps/neofetch) [Neofetch](https://github.com/dylanaraps/neofetch) - A fast, highly customizable system info script that supports Linux, MacOS, iOS, BSD, Solaris, Android, Haiku, GNU Hurd, MINIX, AIX and Windows.
 - [![Open-Source Software][oss icon]](https://github.com/Syllo/nvtop) [NVTOP](https://github.com/Syllo/nvtop) - GPUs process monitoring for AMD, Intel and NVIDIA.
 - [![Open-Source Software][oss icon]](https://github.com/dylanaraps/pfetch) [pfetch](https://github.com/dylanaraps/pfetch) - A pretty system information tool written in POSIX sh.
+- [![Open-Source Software][oss icon]](https://github.com/KittyKatt/screenFetch) [screenFetch](https://github.com/KittyKatt/screenFetch) - Fetches system/theme information in terminal for Linux desktop screenshots.
 - [![Open-Source Software][oss icon]](https://github.com/amanusk/s-tui) [s-tui](https://amanusk.github.io/s-tui/) - s-tui is an UI for monitoring your computer's CPU temperature, frequency and utilization in a graphical way from the terminal.
 
 ### Tools


### PR DESCRIPTION
Adds [screenFetch](https://github.com/KittyKatt/screenFetch); a command-line utility for displaying Linux system information in a visually pleasing way. It has served as inspiration for other projects such as [neofetch](https://github.com/dylanaraps/neofetch).

screenFetch is FOSS ([available on GitHub](https://github.com/KittyKatt/screenFetch)), licensed under the terms of the GNU GPL-3.0 license.