### PR TITLE
Gaming Applications/W.I.N.E.: Add Proton

### DIFF
--- a/README.md
+++ b/README.md
@@ -683,6 +683,7 @@ _For a more comprehensive/advanced/better categorized/... list of Linux audio so
 
 - [![Open-Source Software][oss icon]](https://github.com/GloriousEggroll/proton-ge-custom) [GE-Proton](https://github.com/GloriousEggroll/proton-ge-custom) - Compatibility tool for Steam Play based on Wine and additional components.
 - [![Open-Source Software][oss icon]](https://github.com/Kron4ek/Wine-Builds) [Kron4ek Wine Builds](https://github.com/Kron4ek/Wine-Builds) - Custom Wine builds and build scripts for Vanilla, Wine Staging, Wine-tkg and Proton.
+- [![Open-Source Software][oss icon]](https://github.com/ValveSoftware/Proton) [Proton](https://github.com/ValveSoftware/Proton) - Compatibility tool for Steam Play based on Wine and additional components, primarily developed by Valve and CodeWeavers.
 - [![Open-Source Software][oss icon]](https://github.com/Vysp3r/ProtonPlus) [ProtonPlus](https://github.com/Vysp3r/ProtonPlus) - A simple Wine and Proton manager for GNOME.
 - [![Open-Source Software][oss icon]](https://github.com/Matoking/protontricks) [Protontricks](https://github.com/Matoking/protontricks) - This is a wrapper script that allows you to easily run Winetricks commands for Steam Play/Proton games among other common Wine features, such as launching external Windows executables.
 - [![Open-Source Software][oss icon]](https://github.com/AUNaseef/protonup) [ProtonUp](https://github.com/AUNaseef/protonup) - CLI program and API to automate the installation and update of GE-Proton.


### PR DESCRIPTION
Adds [Proton](https://github.com/ValveSoftware/Proton); a Compatibility Tool primarily for use with the Steam Client based on the [Wine](https://www.winehq.org/) project, with additional components to make for a better out-of-box gaming experience compared to vanilla Wine such as [DXVK](https://github.com/doitsujin/dxvk) and [vkd3d-proton](https://github.com/HansKristian-Work/vkd3d-proton). Proton is primarily developed by [Valve Software](https://www.valvesoftware.com/en/) (including contractors), and [CodeWeavers](https://www.codeweavers.com/).

While Proton can be rather simply [compiled from source](https://github.com/ValveSoftware/Proton#obtaining-proton-sources), Valve do not distribute Proton binaries on GitHub, instead distributing them through the Steam Client.

Proton is Open-Source Software ([available on GitHub](https://github.com/ValveSoftware/Proton)), licensed under the terms of the [BSD-3-Clause License](https://github.com/ValveSoftware/Proton/blob/proton_8.0/LICENSE.proton).