### PR TITLE
Multiple: Add KolourPaint, Moosync, spotDL, SpotiFlyer

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ _For a more comprehensive/advanced/better categorized/... list of Linux audio so
 - [![Open-Source Software][oss icon]](https://gitlab.gnome.org/World/lollypop) [Lollypop](https://wiki.gnome.org/Apps/Lollypop) - A GNOME music playing application.
 - [![Open-Source Software][oss icon]](https://gitlab.com/ColinDuquesnoy/MellowPlayer) [Mellow Player](https://colinduquesnoy.gitlab.io/MellowPlayer/) - Cloud music integration for your desktop.
 - [![Open-Source Software][oss icon]](https://gitlab.com/zehkira/monophony) [Monophony](https://gitlab.com/zehkira/monophony) - Linux app for streaming music from YouTube.
+- [![Open-Source Software][oss icon]](https://github.com/Moosync/Moosync) [Moosync](https://moosync.app/) - Customizable Desktop Music Player with a clean interface for streaming local music as well as music from online sources such as YouTube and Spotify,.
 - [![Open-Source Software][oss icon]](https://github.com/mopidy/mopidy) [Mopidy](https://www.mopidy.com/) - An extensible music server written in Python.
 - [![Open-Source Software][oss icon]](https://github.com/staniel359/muffon) [muffon](https://muffon.netlify.app/) - muffon is a cross-platform music streaming browser for desktop, which helps you find, listen and organize music in a way you've probably never experienced before.
 - [![Open-Source Software][oss icon]](https://github.com/martpie/museeks) [Museeks](https://museeks.io/) - A simple, clean and cross-platform music player.
@@ -771,6 +772,7 @@ _For a more comprehensive/advanced/better categorized/... list of Linux audio so
 - [![Open-Source Software][oss icon]](http://ipe.otfried.org) [Ipe](http://ipe.otfried.org) - Ipe is a LaTeX powered drawing editor for creating figures and presentations in PDF format.
 - [![Open-Source Software][oss icon]](https://invent.kde.org/office/calligra) [Karbon](https://www.calligra.org/karbon/) - An open source vector drawing program.
 - [![Open-Source Software][oss icon]](https://gitlab.com/mattia.basaglia/Knotter) [Knotter](https://knotter.mattbas.org/Knotter) - A Program designed solely to help design and create Celtic Knots.
+- [![Open-Source Software][oss icon]](https://invent.kde.org/graphics/kolourpaint) [KolourPaint](https://apps.kde.org/kolourpaint/) - KolourPaint is a simple painting program to quickly create raster images.
 - [![Open-Source Software][oss icon]](https://invent.kde.org/graphics/krita) [Krita](https://krita.org/en/) - Open Source Software for Concept Artists, Digital Painters, and Illustrators.
 - ![Nonfree][freeware icon][Lunacy](https://icons8.com/lunacy/) - Free design software that keeps your flow with AI tools and built-in graphics
 - [![Open-Source Software][oss icon]](https://github.com/mypaint/mypaint) [Mypaint](https://github.com/mypaint/mypaint)) - Mypaint is a paint program for use with graphics tablets.
@@ -902,6 +904,8 @@ _For a more comprehensive/advanced/better categorized/... list of Linux audio so
 
 - [Clipgrab](https://clipgrab.org/) - A friendly downloader for YouTube and other sites.
 - [![Open-Source Software][oss icon]](https://github.com/NickvisionApps/Parabolic) [Parabolic](https://github.com/NickvisionApps/Parabolic) - Download web video and audio.
+- [![Open-Source Software][oss icon]](https://github.com/spotDL/spotify-downloader) [spotDL](https://github.com/spotDL/spotify-downloader) - Download your Spotify playlists and songs along with album art and metadata (from YouTube if a match is found).
+- [![Open-Source Software][oss icon]](https://github.com/Shabinder/SpotiFlyer) [SpotiFlyer](https://github.com/Shabinder/SpotiFlyer) - Kotlin Multiplatform Music Downloader, Supports Spotify / Gaana / Youtube Music / Jio Saavn / SoundCloud. 
 - [![Open-Source Software][oss icon]](https://github.com/Unrud/video-downloader) [Video Downloader](https://github.com/Unrud/video-downloader) - Download videos from websites like YouTube and many others (based on yt-dlp).
 - [![Open-Source Software][oss icon]](https://github.com/jely2002/youtube-dl-gui) [youtube-dl-gui](https://jely2002.github.io/youtube-dl-gui/) - A cross-platform GUI for youtube-dl made in Electron and node.js
 - [![Open-Source Software][oss icon]](https://github.com/aandrew-me/ytdownloader/) [ytDownloader](https://ytdn.netlify.app/) - A cross-platform GUI for yt-dlp with advanced options and a modern UI.


### PR DESCRIPTION
## Overview
This PR adds the following FOSS applications as requested in #758:
- [KolourPaint](https://invent.kde.org/graphics/kolourpaint); MS Paint-like application, part of the KDE software suite.
- Moosync; Customisable Desktop Music Player that supports streaming music from a variety of sources as well as playing local music.
- spotDL; Uses YouTube to download songs from a Spotify playlist with associated metadata.
    - Though the repository name is `spotify-downloader`, the application appears to go under the name "spotDL".
- SpotiFlyer; Cross-platform music downloading utility that supports a variety of streaming services.
    - Though the program is called SpotiFlyer, they have recently begun promoting some kind of Android app called SoundBound. Perhaps SpotiFlyer is a backend service for this application, [but the SpotiFlyer application](https://github.com/Shabinder/SpotiFlyer/releases/tag/v3.6.3) has releases for Linux, macOS, Windows, and Android.
    - If necessary, SpotiFlyer can be removed from this list.

## Licensing
- KolourPaint is FOSS licensed under the terms of the [GNU GPL v2 Only license](https://invent.kde.org/graphics/kolourpaint/-/blob/master/COPYING).
- Moosync is FOSS licensed under the terms of the [GNU GPL-3.0 license](https://github.com/Moosync/Moosync/blob/main/LICENSE).
- spotDL is FOSS licensed under the terms of the [MIT license](https://github.com/spotDL/spotify-downloader/blob/master/LICENSE).
- SpotiFlyer is FOSS licensed under the terms of the [GNU GPL-3.0 license](https://github.com/Shabinder/SpotiFlyer).