### PR TITLE
Linux News: Add Adventures in Linux and KDE

### DIFF
--- a/README.md
+++ b/README.md
@@ -1733,6 +1733,7 @@ _For a more comprehensive/advanced/better categorized/... list of Linux audio so
 ## Linux News, Apps, and more:
 
 - [9To5Linux](https://9to5linux.com/)
+- [Adventures in Linux and KDE](https://pointieststick.com/)
 - [AllTop](https://linux.alltop.com/)
 - [ArchiveOS](https://archiveos.org/linux/)
 - [Are We Anti-Cheat Yet?](https://areweanticheatyet.com/)


### PR DESCRIPTION
Adds [Adventures in Linux and KDE](https://pointieststick.com/); a KDE news and development blog run by KDE Board Member Nate Graham. This blog usually covers a weekly roundup highlighting KDE-related software developments ("This Week in KDE"), but also contains general Linux / KDE news posts such as information on [the state of Wayland as a protocol](https://pointieststick.com/2023/09/17/so-lets-talk-about-this-wayland-thing/), news of upcoming KDE releases, and overall KDE goals.

Nate Graham is pretty interactive in the article comments, giving useful insights on general KDE progress, goals, and priorities.