### PR TITLE
Linux News: Remove Linux Gaming Central

### DIFF
--- a/README.md
+++ b/README.md
@@ -1759,7 +1759,6 @@ _For a more comprehensive/advanced/better categorized/... list of Linux audio so
 - [Lemmy c/Linux](https://lemmy.ml/c/linux)
 - [Liliputing](https://liliputing.com/)
 - [Linoxide](https://linoxide.com/)
-- [Linux Gaming Central](https://linuxgamingcentral.com/)
 - [LinuxHandbook](https://linuxhandbook.com/)
 - [LinuxLinks](https://www.linuxlinks.com/)
 - [Linux official](https://www.linux.com/)


### PR DESCRIPTION
Linux Gaming Central (added in #708) is shutting down on March 7th, [as per the author's the blog post](https://linuxgamingcentral.com/posts/the-end-of-lgc/) ([Wayback Machine link](https://web.archive.org/web/20240202050828/https://linuxgamingcentral.com/posts/the-end-of-lgc/)). This PR removes it from the "Linux News" section.

Fwiw: Many of the site's articles are backed up on the Internet Archive, the author also suggested to do as much, so the coverage of the site is not necessarily lost :-) 