### PR TITLE
Graphics/Screen Recorder: Add gpu-screen-recorder and gpu-screen-reco…

### DIFF
--- a/README.md
+++ b/README.md
@@ -947,6 +947,8 @@ _For a more comprehensive/advanced/better categorized/... list of Linux audio so
 
 - [![Open-Source Software][oss icon]](https://github.com/asciinema/asciinema) [asciinema](https://asciinema.org) - Terminal session recorder.
 - [![Open-Source Software][oss icon]](https://github.com/dvershinin/green-recorder) [Green Recorder](https://github.com/dvershinin/green-recorder) - A simple desktop recorder for Linux systems, supports recording audio and video on almost all Linux interfaces and Wayland display server on GNOME session.
+- [![Open-Source Software][oss icon]](https://git.dec05eba.com/gpu-screen-recorder) [gpu-screen-recorder](https://git.dec05eba.com/gpu-screen-recorder) - CLI Screen recorder and replay software that uses hardware acceleration similar to AMD ReLive or Nvidia ShadowPlay.
+- [![Open-Source Software][oss icon]](https://git.dec05eba.com/gpu-screen-recorder) [gpu-screen-recorder-git](https://git.dec05eba.com/gpu-screen-recorder-gtk) - Official GTK-based frontend for the CLI tool `gpu-screen-recorder`.
 - [![Open-Source Software][oss icon]](https://code.launchpad.net/kazam) [Kazam](https://launchpad.net/kazam) - An easy to use and very intuitive screen recording program that will capture the content of your screen and record a video file that can be played by any video player that supports VP8/WebM video format.
 - [![Open-Source Software][oss icon]](https://github.com/SeaDve/Kooha) [Kooha](https://flathub.org/apps/io.github.seadve.Kooha) - A simple screen recorder written with GTK. It allows you to record your screen and also audio from your microphone or desktop.
 - [![Open-Source Software][oss icon]](https://github.com/orhun/menyoki) [menyoki](https://menyoki.cli.rs/) - Screen{shot,cast} and perform ImageOps on the command line.


### PR DESCRIPTION
Adds [gpu-screen-recorder](https://git.dec05eba.com/gpu-screen-recorder/about) and its official frontend [gpu-screen-recorder-gtk](https://git.dec05eba.com/gpu-screen-recorder-gtk/about); a hardware accelerated video recorder for capturing high quality footage in a variety of codecs. It is a commandline tool but the author hosts a GTK frontend that sees equally active development.

As well as screen recording, gpu-screen-recorder also offers a replay buffer feature, capturing the last N number of seconds of footage in a buffer. This is useful for gaming where you may want to have this running so you can effectively capture snippets.

gpu-screen-recorder and gpu-screen-recorder-gtk are FOSS ([available git.dec05eba.com](https://git.dec05eba.com/gpu-screen-recorder), licensed under the terms of the GNU GPLv3 license ([gpu-screen-recorder license](https://git.dec05eba.com/gpu-screen-recorder/tree/LICENSE), [gpu-screen-recorder-git license](https://git.dec05eba.com/gpu-screen-recorder-gtk/tree/LICENSE))

<hr>

NOTE: I was unsure about the naming, as most places including most of the README for the official project refer to it as "gpu-screen-recorder", the only exception I saw was [the title for the main repo](https://git.dec05eba.com/gpu-screen-recorder/about) that calls it "GPU Screen Recorder." However the GTK frontend repo then refers to the main tool as "[gpu-screen-recorder](https://git.dec05eba.com/gpu-screen-recorder-gtk/about/)." Let me know if you have any preference on naming. :slightly_smiling_face: 