### PR TITLE
Games/Racing: Add Dr. Robotnik's Ring Racers

### DIFF
--- a/README.md
+++ b/README.md
@@ -726,6 +726,7 @@ _For a more comprehensive/advanced/better categorized/... list of Linux audio so
 
 #### Racing
 
+- [![Open-Source Software][oss icon]](https://github.com/KartKrewDev/RingRacers/) [Dr. Robotnik's Ring Racers](https://www.kartkrew.org/) - A technical kart racer, drawing inspiration from “antigrav” racers, fighting games, and traditional-style kart racing.
 - [![Open-Source Software][oss icon]](https://motogt.sourceforge.net/) [MotoGT](https://motogt.sourceforge.net/) - 2D top-viewed game where you drive a MotoGP bike.
 - [![Open-Source Software][oss icon]](https://github.com/supertuxkart/stk-code) [SuperTuxKart](https://supertuxkart.net) - SuperTuxKart is a 3D open-source arcade racer with a variety characters, tracks, and modes to play.
 - [![Open-Source Software][oss icon]](https://xmoto.tuxfamily.org/index.php) [XMoto](https://xmoto.tuxfamily.org/) - 2D motocross physics-based game requiring a lot of skill to master, with a built-in replay-recording and sharing system.


### PR DESCRIPTION
Adds [Dr. Robotnik's Ring Racers](https://www.kartkrew.org/); a cross-platform technical kart racer inspired by a various gaming genres and a Sonic fan game.

The Linux version is only distributed as a Flatpak, but the game can be compiled from source for Linux as well following guidance on the project's README. So while it is not _as_ readily available for Linux as one might like, it isn't running in some kind of emulated environment and is Linux native software.

Dr. Robotnik's Ring Racers is FOSS ([available on GitHub](https://github.com/KartKrewDev/RingRacers/) and [available on GitLab](https://git.srb2.org/KartKrew/RingRacers)), licensed under the terms of the GNU GPL-2.0 license.