### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,8 +160,9 @@
 
 ### 3D Printing
 
-- [Cura](https://ultimaker.com/software/ultimaker-cura/) - The worlds most advanced 3D printer software
+- [![Open-Source Software][oss icon]](https://github.com/Ultimaker/Cura) [Cura](https://ultimaker.com/software/ultimaker-cura/) - The worlds most advanced 3D printer software
 - [![Open-Source Software][oss icon]](https://github.com/FreeCAD) [FreeCAD](https://www.freecad.org/) - An open source parametric 3D CAD modeler
+- [![Open-Source Software][oss icon]](https://github.com/prusa3d/PrusaSlicer) [PrusaSlicer](https://www.prusa3d.com/page/prusaslicer_424/) - A slicer based on Slic3r by Alessandro Ranellucci and the RepRap community
 
 ### Audio
 


### PR DESCRIPTION
Updated Cura to being open sourced and PrusaSlicer as it is another prevalent open sourced 3D printing slicer (Note; it is a part of Prusa3D, but it is applicable with all RepRap based 3D printers).