### PR TITLE
Removed link https://linoxide.com/...

### DIFF
--- a/README.md
+++ b/README.md
@@ -1789,7 +1789,6 @@ _For a more comprehensive/advanced/better categorized/... list of Linux audio so
 - [ITSFOSS](https://itsfoss.com/)
 - [Lemmy c/Linux](https://lemmy.ml/c/linux)
 - [Liliputing](https://liliputing.com/)
-- [Linoxide](https://linoxide.com/)
 - [LinuxHandbook](https://linuxhandbook.com/)
 - [LinuxLinks](https://www.linuxlinks.com/)
 - [Linux official](https://www.linux.com/)

--- a/Readme_ar-AR.md
+++ b/Readme_ar-AR.md
@@ -1780,7 +1780,6 @@
 - [ITSFOSS](https://itsfoss.com/)
 - [ليمي سي/لينكس](https://lemmy.ml/c/linux)
 - [ليليبوتينغ](https://liliputing.com/)
-- [لينوكسيد](https://linoxide.com/)
 - [LinuxHandbook](https://linuxhandbook.com/)
 - [لينكس لينك](https://www.linuxlinks.com/)
 - [الرسمي لينكس](https://www.linux.com/)


### PR DESCRIPTION
https://linoxide.com/ is not reachable anymore (hasn't been indexed by archive.org since the beginning of 2024). Removed it