### PR TITLE
Fixed link https://github.com/GNOME/glade...

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,7 +538,7 @@ _For a more comprehensive/advanced/better categorized/... list of Linux audio so
 - [![Open-Source Software][oss icon]](https://www.fossil-scm.org/index.html/dir?ci=tip) [Fossil](https://www.fossil-scm.org) - Self-contained, distributed software configuration management system with integrated bug-tracking, wiki, technotes and web interface.
 - [![Open-Source Software][oss icon]](https://github.com/gaphor/gaphor) [Gaphor](https://gaphor.org) - A simple and fast software and systems modeling tool.
 - ![Nonfree][money icon] [Genymotion](https://www.genymotion.com/desktop/) - Genymotion is a fast third-party emulator that can be used instead of the default Android emulator.
-- [![Open-Source Software][oss icon]](https://github.com/GNOME/glade) [Glade](https://github.com/GNOME/glade) - GTK+ User Interface Builder.
+- [![Open-Source Software][oss icon]](https://gitlab.gnome.org/Archive/glade) [Glade](https://gitlab.gnome.org/Archive/glade) - GTK+ User Interface Builder.
 - [![Open-Source Software][oss icon]](https://phabricator.kde.org/source/heaptrack/repository/master/) [Heaptrack](https://phabricator.kde.org/source/heaptrack/repository/master/) - A heap memory profiler for Linux.
 - [![Open-Source Software][oss icon]](https://github.com/WindSoilder/hors) [hors](https://github.com/WindSoilder/hors) - Instant coding answers via the command line.
 - [![Open-Source Software][oss icon]](https://github.com/Kong/insomnia) [Insomnia](https://insomnia.rest/) - A simple, beautiful, and free REST API client.

--- a/Readme_ar-AR.md
+++ b/Readme_ar-AR.md
@@ -534,7 +534,7 @@
 - [![برمجيات مفتوحة المصدر][أيقونة oss]](https://www.fossil-scm.org/index.html/dir?ci=tip) [Fossil](https://www.fossil-scm.org) - نظام إدارة تكوين برمجيات موزع ومستقل مع تتبع الأخطاء المتكامل، وويكي، وملاحظات تقنية، وواجهة ويب.
 - [![برمجيات مفتوحة المصدر][أيقونة oss]](https://github.com/gaphor/gaphor) [Gaphor](https://gaphor.org) - أداة نمذجة برمجيات وأنظمة بسيطة وسريعة.
 - ![غير مجاني][أيقونة المال] [Genymotion](https://www.genymotion.com/desktop/) - Genymotion هو محاكي سريع تابع لجهة خارجية يمكن استخدامه بدلاً من محاكي Android الافتراضي.
-- [![برمجيات مفتوحة المصدر][أيقونة oss]](https://github.com/GNOME/glade) [Glade](https://github.com/GNOME/glade) - منشئ واجهة المستخدم GTK+.
+- [![برمجيات مفتوحة المصدر][أيقونة oss]](https://gitlab.gnome.org/Archive/glade) [Glade](https://gitlab.gnome.org/Archive/glade) - منشئ واجهة المستخدم GTK+.
 - [![برمجيات مفتوحة المصدر][أيقونة oss]](https://phabricator.kde.org/source/heaptrack/repository/master/) [Heaptrack](https://phabricator.kde.org/source/heaptrack/repository/master/) - أداة تحليل ذاكرة الكومة لنظام Linux.
 - [![برمجيات مفتوحة المصدر][أيقونة oss]](https://github.com/WindSoilder/hors) [hors](https://github.com/WindSoilder/hors) - إجابات ترميز فورية عبر سطر الأوامر.
 - [![برمجيات مفتوحة المصدر][أيقونة oss]](https://github.com/Kong/insomnia) [Insomnia](https://insomnia.rest/) - عميل API REST بسيط وجميل ومجاني.


### PR DESCRIPTION
https://github.com/GNOME/glade is old and/or not reachable; Replaced it with https://gitlab.gnome.org/Archive/glade